### PR TITLE
1.19.30+ format requirements

### DIFF
--- a/packages/create-beapi/template-typescript/manifest.json
+++ b/packages/create-beapi/template-typescript/manifest.json
@@ -22,18 +22,18 @@
       "entry": "scripts/index.js"
     }
   ],
-  "dependencies": [
-    {
-      "uuid": "b26a4d4c-afdf-4690-88f8-931846312678",
-      "version": [0, 1, 0]
-    },
-    {
-      "uuid": "6f4b6893-1bb6-42fd-b458-7fa3d0c89616",
-      "version": [0, 1, 0]
-    },
-    {
-      "uuid": "2bd50a27-aB5f-4f40-a596-3641627c635e",
-      "version": [0, 1, 0]
-    }
-  ]
+  "dependencies":  [
+      {
+        "uuid": "b26a4d4c-afdf-4690-88f8-931846312678",
+        "version": "1.0.0-beta"
+      },
+      {
+        "uuid": "6f4b6893-1bb6-42fd-b458-7fa3d0c89616",
+        "version": "1.0.0-beta"
+      },
+      {
+        "uuid": "2bd50a27-aB5f-4f40-a596-3641627c635e",
+        "version": "1.0.0-beta"
+      }
+   ]
 }


### PR DESCRIPTION
 Updated to meet the new manifest format requirements introduced in 1.19.30

Ref: [MS Docs](https://learn.microsoft.com/en-us/minecraft/creator/documents/gametestbuildyourfirstgametest#update-your-manifest) | [Update Docs](https://www.minecraft.net/en-us/article/1-19-30-update-available-bedrock#GameTest-Framework) | [Minecraft Module](https://learn.microsoft.com/minecraft/creator/scriptapi/mojang-minecraft/mojang-minecraft) | [Gametest Module](https://learn.microsoft.com/minecraft/creator/scriptapi/mojang-gametest/mojang-gametest) | [UI Module](https://learn.microsoft.com/minecraft/creator/scriptapi/mojang-minecraft-ui/mojang-minecraft-ui)